### PR TITLE
ci: test generating lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,64 @@
     "": {
       "name": "gen-lockfile-poc",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "is-even": "^1.0.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-even": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-even/-/is-even-1.0.0.tgz",
+      "integrity": "sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-odd": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-odd": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
+      "integrity": "sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "description": "testing gh actions",
   "main": "index.js",
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "is-even": "^1.0.0"
+  }
 }


### PR DESCRIPTION
[gen-lockfile.webm](https://github.com/user-attachments/assets/5ce9e1ee-598b-4ceb-a6c5-1e7bd63dcce8)

An action that can be manually triggered to generate a new `package-lock.json`.

We can't test this action until it's merged 🙃 since [it's a workflow_dispatch event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch).

> This event will only trigger a workflow run if the workflow file exists on the default branch.

(We can probably configure it to run when someone makes a push that changes a package.json if we wanted to.)

## Potential Problems
- Do we need to whitelist a bot to allow it to touch `package-lock.json`?
- Will there be problems merging a PR that touches package-lock.json if *you're* not allowed to touch package-lock.json?

## Annoyances
- Since `package-lock.json` is already in the repo, you seemingly can't .gitignore it, and it's up to you to not commit changes
- You have to manually trigger it, and search through the branches to get yours