### PR TITLE
ci: test gen-package-lock

### DIFF
--- a/.github/workflows/generate-package-lock.yml
+++ b/.github/workflows/generate-package-lock.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   generate-lockfile:
-    if: github.ref_name != 'main'  # This should only be run on PRs
+    if: ! contains(fromJSON('["main"]'), github.ref_name)  # This should only be run on PRs
 
     name: Generate package-lock.json
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,64 @@
     "": {
       "name": "gen-lockfile-poc",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "is-even": "^1.0.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-even": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-even/-/is-even-1.0.0.tgz",
+      "integrity": "sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-odd": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-odd": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
+      "integrity": "sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "description": "testing gh actions",
   "main": "index.js",
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "is-even": "^1.0.0"
+  }
 }


### PR DESCRIPTION
[gen-lockfile.webm](https://github.com/user-attachments/assets/5ce9e1ee-598b-4ceb-a6c5-1e7bd63dcce8)

An action that can be manually triggered to generate a new `package-lock.json`.

We can't test this action until it's merged 🙃 since [it's a workflow_dispatch event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch). This is a test repo I've made to test this action

> This event will only trigger a workflow run if the workflow file exists on the default branch.

(We can probably configure it to run when someone makes a push that changes a package.json if we wanted to.)

## Questions
- Do we need to whitelist the bot to allow it to touch `package-lock.json`?
  - "github-actions[bot]" <41898282+github-actions[bot]@users.noreply.github.com>
- Will there be problems merging a PR that touches package-lock.json if *you're* not allowed to touch package-lock.json?

## Annoyances
- Since `package-lock.json` is already in the repo, you seemingly can't .gitignore it, and it's up to you to not commit changes or risk trying to push your commits and getting denied
- You have to manually trigger the action, and search through the branches to get yours